### PR TITLE
Provide basic CI support using Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,4 +1,4 @@
-box: jakirkham/centos_drmaa_conda
+box: jakirkham/ubuntu_drmaa_conda
 build:
     steps:
         - script:

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -5,6 +5,7 @@ build:
             name: Build Conda Package.
             code: |-
                 conda config --add channels http://conda.binstar.org/jakirkham
+                conda config --set show_channel_urls True
                 source activate root
                 python setup.py bdist_conda
 

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,4 +1,4 @@
-box: jakirkham/ubuntu_drmaa_conda
+box: jakirkham/centos_drmaa_conda
 build:
     steps:
         - script:

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -4,7 +4,6 @@ build:
         - script:
             name: Build Conda Package.
             code: |-
-                conda config --set always_yes yes
                 conda config --add channels http://conda.binstar.org/jakirkham
                 source activate root
                 python setup.py bdist_conda
@@ -12,28 +11,28 @@ build:
         - script:
             name: Create Conda Environment with package and dependencies.
             code: |-
-                conda create -n nanshenv python=2.7
+                conda create -y -n nanshenv python=2.7
                 source activate nanshenv
-                conda install --use-local nanshe==$(python setup.py --version)
+                conda install -y --use-local nanshe==$(python setup.py --version)
 
         - script:
             name: Install dependencies for cluster support.
             code: |-
-                conda install drmaa
+                conda install -y drmaa
 
         - script:
             name: Install dependencies for building docs.
             code: |-
-                conda install "sphinx>=1.3,<2"
-                conda install cloud_sptheme
+                conda install -y "sphinx>=1.3,<2"
+                conda install -y cloud_sptheme
 
         - script:
             name: Install dependencies for profiling and monitoring coverage.
             code: |-
-                conda install nose-timer
-                conda install coverage
-                conda install docstring-coverage
-                conda install python-coveralls
+                conda install -y nose-timer
+                conda install -y coverage
+                conda install -y docstring-coverage
+                conda install -y python-coveralls
 
         - script:
             name: Test code.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -1,0 +1,47 @@
+box: jakirkham/centos_drmaa_conda
+build:
+    steps:
+        - script:
+            name: Build Conda Package.
+            code: |-
+                conda config --set always_yes yes
+                conda config --add channels http://conda.binstar.org/jakirkham
+                source activate root
+                python setup.py bdist_conda
+
+        - script:
+            name: Create Conda Environment with package and dependencies.
+            code: |-
+                conda create -n nanshenv python=2.7
+                source activate nanshenv
+                conda install --use-local nanshe==$(python setup.py --version)
+
+        - script:
+            name: Install dependencies for cluster support.
+            code: |-
+                conda install drmaa
+
+        - script:
+            name: Install dependencies for building docs.
+            code: |-
+                conda install "sphinx>=1.3,<2"
+                conda install cloud_sptheme
+
+        - script:
+            name: Install dependencies for profiling and monitoring coverage.
+            code: |-
+                conda install nose-timer
+                conda install coverage
+                conda install docstring-coverage
+                conda install python-coveralls
+
+        - script:
+            name: Test code.
+            code: |-
+                python setup.py nosetests --with-timer
+
+        - script:
+            name: Test documentation.
+            code: |-
+                python setup.py build_sphinx
+                docstring-coverage nanshe | tee .docstring-coverage

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -35,6 +35,11 @@ build:
                 conda install -y python-coveralls
 
         - script:
+            name: Clean the environment.
+            code: |-
+                conda clean -tipsy
+
+        - script:
             name: Test code.
             code: |-
                 python setup.py nosetests --with-timer

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -13,9 +13,8 @@ build:
         - script:
             name: Create Conda Environment with package and dependencies.
             code: |-
-                conda create -y -n nanshenv python=2.7
+                conda create -y --use-local -n nanshenv nanshe==$(python setup.py --version)
                 source activate nanshenv
-                conda install -y --use-local nanshe==$(python setup.py --version)
 
         - script:
             name: Install dependencies for cluster support.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -7,6 +7,7 @@ build:
                 conda config --add channels http://conda.binstar.org/jakirkham
                 conda config --set show_channel_urls True
                 source activate root
+                conda update -y --all
                 python setup.py bdist_conda
 
         - script:

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |Coverage Status| |Code Health| |License| |Documentation| |Binstar Release|
+|Travis Build Status| |Wercker Build Status| |Coverage Status| |Code Health| |License| |Documentation| |Binstar Release|
 
 --------------
 
@@ -153,8 +153,10 @@ configuration file. For certain fields, like those in
 "min" and/or "max". If both are specified, then the range must be met.
 If only one is specified, then only an upper or lower bound exists.
 
-.. |Build Status| image:: https://travis-ci.org/jakirkham/nanshe.svg?branch=master
+.. |Travis Build Status| image:: https://travis-ci.org/jakirkham/nanshe.svg?branch=master
    :target: https://travis-ci.org/jakirkham/nanshe
+.. |Wercker Build Status| image:: https://app.wercker.com/status/1ed421adbbec48aac2a370817dc0410f/s/master
+   :target: https://app.wercker.com/project/bykey/1ed421adbbec48aac2a370817dc0410f
 .. |Coverage Status| image:: https://coveralls.io/repos/jakirkham/nanshe/badge.svg?branch=master
    :target: https://coveralls.io/r/jakirkham/nanshe?branch=master
 .. |Code Health| image:: https://landscape.io/github/jakirkham/nanshe/master/landscape.svg?style=flat


### PR DESCRIPTION
Fixes jakirkham/nanshe#242.

Allows for CI support using Wercker. Starts with a custom Docker container that already contains Grid Engine installed and configured. Works nicely with `drmaa` bindings for Python out-of-the-box.