### PR TITLE
binstar.org to anaconda.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
    - export PATH="$HOME/miniconda/bin:$PATH"
    - conda config --set always_yes yes
    - conda config --set show_channel_urls True
-   - conda config --add channels http://conda.binstar.org/jakirkham
+   - conda config --add channels http://conda.anaconda.org/jakirkham
    - source activate root
    # Install basic conda dependencies.
    - conda update --all

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -4,7 +4,7 @@ build:
         - script:
             name: Build Conda Package.
             code: |-
-                conda config --add channels http://conda.binstar.org/jakirkham
+                conda config --add channels http://conda.anaconda.org/jakirkham
                 conda config --set show_channel_urls True
                 source activate root
                 conda update -y --all

--- a/README.rst
+++ b/README.rst
@@ -165,5 +165,5 @@ If only one is specified, then only an upper or lower bound exists.
    :target: https://www.gnu.org/copyleft/gpl.html
 .. |Documentation| image:: https://img.shields.io/badge/docs-current-9F21E9.svg
    :target: http://jakirkham.github.io/nanshe/
-.. |Binstar Release| image:: https://binstar.org/jakirkham/nanshe/badges/version.svg
-   :target: https://binstar.org/jakirkham/nanshe
+.. |Binstar Release| image:: https://anaconda.org/jakirkham/nanshe/badges/version.svg
+   :target: https://anaconda.org/jakirkham/nanshe

--- a/nanshe/__init__.py
+++ b/nanshe/__init__.py
@@ -61,14 +61,14 @@ preferable.
 
 Conda
 ===============================================================================
-Current packages can be found on our binstar_ channel
-( https://binstar.org/jakirkham/nanshe ). New ones are released every time a
+Current packages can be found on our anaconda_ channel
+( https://anaconda.org/jakirkham/nanshe ). New ones are released every time a
 passing tagged release is pushed to the ``master`` branch on GitHub. It is also
 possible to build packages for conda_ for non-release commits as we do in our
 continuous integration strategy.
 
 To do this one requires the dependencies be installed or be available from a
-binstar channel. Additionally, one must be using the conda's ``root``
+anaconda channel. Additionally, one must be using the conda's ``root``
 environment and have conda-build installed. Once this is done one need
 only the run the following command with ``setup.py``.
 
@@ -182,7 +182,7 @@ clean all command will do this.
 .. _`Intel MKL`: http://software.intel.com/en-us/intel-mkl
 .. _R: http://www.r-project.org/
 .. _setuptools: http://pythonhosted.org/setuptools/
-.. _binstar: https://binstar.org/
+.. _anaconda: https://anaconda.org/
 .. _conda: http://conda.pydata.org/
 .. _nose: http://nose.readthedocs.org/en/latest/
 .. _drmaa: http://github.com/pygridtools/drmaa-python


### PR DESCRIPTION
[binstar.org]( http://binstar.org ) is being moved to [anaconda.org]( http://anaconda.org ). This can be evidenced by this brief note on top of this article ( http://continuum.io/blog/binstar ) and emails Continuum has been sending out. As a consequence, this PR simply replaces all the links to point [anaconda.org]( http://anaconda.org ).