### PR TITLE
Make use of cloud theme for sphinx optional

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,10 @@
 import sys
 import os
 
-import cloud_sptheme
+try:
+    import cloud_sptheme
+except:
+    cloud_sptheme = None
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -109,7 +112,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'cloud'
+html_theme = 'cloud' if cloud_sptheme else 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -117,7 +120,7 @@ html_theme = 'cloud'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [cloud_sptheme.get_theme_dir()]
+html_theme_path = [cloud_sptheme.get_theme_dir()] if cloud_sptheme else []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
Will use the default theme if cloud theme cannot be found when building the documentation. If cloud theme can be found, it will be used in place of the default.