### PR TITLE
Support initial dictionary provided to SPAMS

### DIFF
--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -290,9 +290,10 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
         lock=False
     )
 
+    new_args = (result_array_type, result_array, X_array_type, X_array,) + args
     p = multiprocessing.Process(
         target=run_multiprocessing_array_spams_trainDL,
-        args=(result_array_type, result_array, X_array_type, X_array,) + args,
+        args=new_args,
         kwargs=kwargs
     )
     p.start()

--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -171,8 +171,8 @@ def run_multiprocessing_array_spams_trainDL(result_array_type,
     import spams
 
     as_ordered_array_dict = {
-        "F_CONTIGUOUS" : numpy.asfortranarray,
-        "C_CONTIGUOUS" : numpy.ascontiguousarray
+        "F_CONTIGUOUS": numpy.asfortranarray,
+        "C_CONTIGUOUS": numpy.ascontiguousarray
     }
 
     # Construct X from shared array.

--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -246,6 +246,15 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
     # Just to make sure this exists in the new process. Shouldn't be necessary.
     import numpy
 
+    D_is_arg = False
+    D = None
+    if (len(args) >= 4):
+        D_is_arg = True
+        D = args[4]
+        args[4] = None
+    else:
+        D = kwargs.pop("D", None)
+
     # Types for X_array
     X_array_type = numpy.ctypeslib.ndpointer(
         dtype=X.dtype, ndim=X.ndim, shape=X.shape, flags=X.flags

--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -175,7 +175,6 @@ def run_multiprocessing_array_spams_trainDL(result_array_type,
         "C_CONTIGUOUS" : numpy.ascontiguousarray
     }
 
-
     # Construct X from shared array.
     X_dtype = X_array_type._dtype_
     X_shape = X_array_type._shape_
@@ -201,7 +200,6 @@ def run_multiprocessing_array_spams_trainDL(result_array_type,
     for order_name, as_ordered_array in as_ordered_array_dict.items():
         if order_name in result_array_type.__name__:
             result = as_ordered_array(result)
-
 
     result[:] = spams.trainDL(X, *args, **kwargs)
 
@@ -248,7 +246,6 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
     # Just to make sure this exists in the new process. Shouldn't be necessary.
     import numpy
 
-
     # Types for X_array
     X_array_type = numpy.ctypeslib.ndpointer(
         dtype=X.dtype, ndim=X.ndim, shape=X.shape, flags=X.flags
@@ -269,7 +266,6 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
     X_array_numpy[:] = X
     X_array_numpy = None
 
-
     # Types for result_array
     result_array_type = numpy.ctypeslib.ndpointer(
         dtype=X.dtype, ndim=X.ndim, shape=(X.shape[0], kwargs["K"])
@@ -285,7 +281,6 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
         lock=False
     )
 
-
     p = multiprocessing.Process(
         target=run_multiprocessing_array_spams_trainDL,
         args=(result_array_type, result_array, X_array_type, X_array,) + args,
@@ -297,7 +292,6 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
     if p.exitcode != 0: raise SPAMSException(
         "SPAMS has terminated with exitcode \"" + repr(p.exitcode) + "\"."
     )
-
 
     # Reconstruct the result from the output array
     result = numpy.frombuffer(

--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -117,6 +117,9 @@ def run_multiprocessing_array_spams_trainDL(result_array_type,
                                             result_array,
                                             X_array_type,
                                             X_array,
+                                            D_is_arg=False,
+                                            D_array_type=None,
+                                            D_array=None,
                                             *args,
                                             **kwargs):
     """
@@ -186,6 +189,24 @@ def run_multiprocessing_array_spams_trainDL(result_array_type,
     for order_name, as_ordered_array in as_ordered_array_dict.items():
         if order_name in X_array_type.__name__:
             X = as_ordered_array(X)
+
+    # Construct D from shared array.
+    if (D_array_type is not None) and (D_array is not None):
+        D_dtype = D_array_type._dtype_
+        D_shape = D_array_type._shape_
+        D_flags = numpy.core.multiarray.flagsobj(D_array_type._flags_)
+
+        D = numpy.frombuffer(D_array, dtype=D_dtype).reshape(D_shape)
+        D.setflags(D_flags)
+
+        for order_name, as_ordered_array in as_ordered_array_dict.items():
+            if order_name in D_array_type.__name__:
+                D = as_ordered_array(D)
+
+        if D_is_arg:
+            args[3] = D
+        else:
+            kwargs["D"] = D
 
     # Construct the result to use the shared buffer.
     result_dtype = result_array_type._dtype_

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -809,7 +809,7 @@ def generate_dictionary(new_data, **parameters):
     # Need to look into generating the sparse code given the dictionary,
     # spams.nmf? (may be too slow))
     new_dictionary = nanshe.box.spams_sandbox.call_multiprocessing_array_spams_trainDL(
-        new_data_processed,
+        X=new_data_processed,
         **parameters["spams.trainDL"]
     )
 

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -747,7 +747,7 @@ def preprocess_data(new_data, out=None, **parameters):
 
 @prof.log_call(trace_logger)
 @hdf5.record.static_array_debug_recorder
-def generate_dictionary(new_data, **parameters):
+def generate_dictionary(new_data, initial_dictionary=None, **parameters):
     """
         Generates a dictionary using the data and parameters given for trainDL.
 
@@ -755,6 +755,9 @@ def generate_dictionary(new_data, **parameters):
             new_data(numpy.ndarray):            array of data for generating a
                                                 dictionary (first axis is
                                                 time).
+
+            initial_dictionary(numpy.ndarray):  dictionary to start the
+                                                algorithm with.
 
             **parameters(dict):                 passed directly to
                                                 spams.trainDL.
@@ -805,11 +808,34 @@ def generate_dictionary(new_data, **parameters):
     # Spams requires all matrices to be fortran.
     new_data_processed = numpy.asfortranarray(new_data_processed)
 
+    # If there is an initial dictionary provided, go ahead and process it.
+    initial_dictionary_processed = initial_dictionary
+    if initial_dictionary_processed is not None:
+        # Go ahead and make the dictionary the same type as the input data.
+        # TODO: Add a warning if it needs to be down cast
+        initial_dictionary_processed = numpy.asarray(
+            initial_dictionary_processed, dtype=float_dtype
+        )
+
+        # Reshape dictionary into a matrix (each image is now a column vector)
+        initial_dictionary_processed = xnumpy.array_to_matrix(
+            initial_dictionary_processed
+        )
+        initial_dictionary_processed = numpy.asmatrix(
+            initial_dictionary_processed
+        )
+        initial_dictionary_processed = initial_dictionary_processed.transpose()
+
+        # Spams requires all matrices to be fortran.
+        initial_dictionary_processed = numpy.asfortranarray(
+            initial_dictionary_processed
+        )
+
     # Simply trains the dictionary. Does not return sparse code.
     # Need to look into generating the sparse code given the dictionary,
     # spams.nmf? (may be too slow))
     new_dictionary = nanshe.box.spams_sandbox.call_multiprocessing_array_spams_trainDL(
-        X=new_data_processed,
+        X=new_data_processed, D=initial_dictionary_processed,
         **parameters["spams.trainDL"]
     )
 
@@ -818,7 +844,7 @@ def generate_dictionary(new_data, **parameters):
     new_dictionary = new_dictionary.transpose()
     new_dictionary = numpy.asarray(new_dictionary, dtype=new_data.dtype.type)
     new_dictionary = new_dictionary.reshape(
-        (parameters["spams.trainDL"]["K"],) + new_data.shape[1:]
+        (-1,) + new_data.shape[1:]
     )
 
     return(new_dictionary)

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -32,14 +32,18 @@ class TestSpamsSandbox(object):
         self.space3 = numpy.array((100, 100, 100))
         self.radii = numpy.array((5, 6, 7))
 
-        self.g = nanshe.syn.data.generate_hypersphere_masks(self.space, self.p, self.radii)
+        self.g = nanshe.syn.data.generate_hypersphere_masks(
+            self.space, self.p, self.radii
+        )
 
         self.g = self.g.reshape((self.g.shape[0], -1))
         self.g = self.g.transpose()
         self.g = numpy.asmatrix(self.g)
         self.g = numpy.asfortranarray(self.g)
 
-        self.g3 = nanshe.syn.data.generate_hypersphere_masks(self.space3, self.p3, self.radii)
+        self.g3 = nanshe.syn.data.generate_hypersphere_masks(
+            self.space3, self.p3, self.radii
+        )
 
         self.g3 = self.g3.reshape((self.g3.shape[0], -1))
         self.g3 = self.g3.transpose()
@@ -241,17 +245,41 @@ class TestSpamsSandbox(object):
     def test_run_multiprocessing_array_spams_trainDL_1(self):
         float_type = numpy.float64
 
-        g_array_type = numpy.ctypeslib.ndpointer(dtype=float_type, ndim=self.g.ndim, shape=self.g.shape, flags=self.g.flags)
-        g_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(g_array_type._dtype_.type).type(0)[()]))
-        g_array = multiprocessing.Array(g_array_ctype, numpy.product(g_array_type._shape_), lock=False)
+        g_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=self.g.ndim,
+            shape=self.g.shape,
+            flags=self.g.flags
+        )
+        g_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            g_array_type._dtype_.type
+        ).type(0)[()]))
+        g_array = multiprocessing.Array(
+            g_array_ctype,
+            numpy.product(g_array_type._shape_),
+            lock=False
+        )
 
-        g_numpy_array = numpy.frombuffer(g_array, dtype=g_array_type._dtype_).reshape(g_array_type._shape_)
+        g_numpy_array = numpy.frombuffer(
+            g_array,
+            dtype=g_array_type._dtype_
+        ).reshape(g_array_type._shape_)
         g_numpy_array[:] = self.g
         g_numpy_array = None
 
-        result_array_type = numpy.ctypeslib.ndpointer(dtype=float_type, ndim=2, shape=(self.g.shape[0], self.g.shape[1]))
-        result_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(result_array_type._dtype_.type).type(0)[()]))
-        result_array = multiprocessing.Array(result_array_ctype, numpy.product(result_array_type._shape_), lock=False)
+        result_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=2,
+            shape=(self.g.shape[0], self.g.shape[1])
+        )
+        result_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            result_array_type._dtype_.type
+        ).type(0)[()]))
+        result_array = multiprocessing.Array(
+            result_array_ctype,
+            numpy.product(result_array_type._shape_),
+            lock=False
+        )
 
         nanshe.box.spams_sandbox.run_multiprocessing_array_spams_trainDL(
             result_array_type,
@@ -274,7 +302,10 @@ class TestSpamsSandbox(object):
                 "mode" : 2
             }
         )
-        d = numpy.frombuffer(result_array, dtype=float_type).reshape(result_array_type._shape_).copy()
+        d = numpy.frombuffer(
+            result_array,
+            dtype=float_type
+        ).reshape(result_array_type._shape_).copy()
         d = (d != 0)
 
         self.g = self.g.transpose()
@@ -305,17 +336,41 @@ class TestSpamsSandbox(object):
     def test_run_multiprocessing_array_spams_trainDL_2(self):
         float_type = numpy.float64
 
-        g3_array_type = numpy.ctypeslib.ndpointer(dtype=float_type, ndim=self.g3.ndim, shape=self.g3.shape, flags=self.g3.flags)
-        g3_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(g3_array_type._dtype_.type).type(0)[()]))
-        g3_array = multiprocessing.Array(g3_array_ctype, numpy.product(g3_array_type._shape_), lock=False)
+        g3_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=self.g3.ndim,
+            shape=self.g3.shape,
+            flags=self.g3.flags
+        )
+        g3_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            g3_array_type._dtype_.type
+        ).type(0)[()]))
+        g3_array = multiprocessing.Array(
+            g3_array_ctype,
+            numpy.product(g3_array_type._shape_),
+            lock=False
+        )
 
-        g3_numpy_array = numpy.frombuffer(g3_array, dtype=g3_array_type._dtype_).reshape(g3_array_type._shape_)
+        g3_numpy_array = numpy.frombuffer(
+            g3_array,
+            dtype=g3_array_type._dtype_
+        ).reshape(g3_array_type._shape_)
         g3_numpy_array[:] = self.g3
         g3_numpy_array = None
 
-        result_array_type = numpy.ctypeslib.ndpointer(dtype=float_type, ndim=2, shape=(self.g3.shape[0], self.g3.shape[1]))
-        result_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(result_array_type._dtype_.type).type(0)[()]))
-        result_array = multiprocessing.Array(result_array_ctype, numpy.product(result_array_type._shape_), lock=False)
+        result_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=2,
+            shape=(self.g3.shape[0], self.g3.shape[1])
+        )
+        result_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            result_array_type._dtype_.type
+        ).type(0)[()]))
+        result_array = multiprocessing.Array(
+            result_array_ctype,
+            numpy.product(result_array_type._shape_),
+            lock=False
+        )
 
         nanshe.box.spams_sandbox.run_multiprocessing_array_spams_trainDL(
             result_array_type,
@@ -338,7 +393,10 @@ class TestSpamsSandbox(object):
                 "mode" : 2
             }
         )
-        d3 = numpy.frombuffer(result_array, dtype=float_type).reshape(result_array_type._shape_).copy()
+        d3 = numpy.frombuffer(
+            result_array,
+            dtype=float_type
+        ).reshape(result_array_type._shape_).copy()
         d3 = (d3 != 0)
 
         self.g3 = self.g3.transpose()

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -853,6 +853,7 @@ class TestSpamsSandbox(object):
             result_array,
             g3_array_type,
             g3_array,
+            False,
             g3_array_type,
             g3_array,
             **{
@@ -1044,7 +1045,7 @@ class TestSpamsSandbox(object):
     def test_call_spams_trainDL_4(self):
         d3 = nanshe.box.spams_sandbox.call_spams_trainDL(
             self.g3.astype(float),
-            self.g3.astype(float),
+            D=self.g3.astype(float),
             **{
                 "gamma2" : 0,
                 "gamma1" : 0,

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -151,6 +151,111 @@ class TestSpamsSandbox(object):
 
         assert (len(unmatched_g3) == 0)
 
+    def test_run_multiprocessing_queue_spams_trainDL_3(self):
+        out_queue = multiprocessing.Queue()
+
+        nanshe.box.spams_sandbox.run_multiprocessing_queue_spams_trainDL(
+            out_queue,
+            self.g.astype(float),
+            D=self.g.astype(float),
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d = out_queue.get()
+
+        d = (d != 0)
+
+        self.g = self.g.transpose()
+        d = d.transpose()
+
+        assert (self.g.shape == d.shape)
+
+        assert (self.g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(self.g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == self.g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (self.g.astype(bool) == d.astype(bool)).all()
+
+    @nose.plugins.attrib.attr("3D")
+    def test_run_multiprocessing_queue_spams_trainDL_4(self):
+        out_queue = multiprocessing.Queue()
+
+        nanshe.box.spams_sandbox.run_multiprocessing_queue_spams_trainDL(
+            out_queue,
+            self.g3.astype(float),
+            D=self.g3.astype(float),
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d3 = out_queue.get()
+
+        d3 = (d3 != 0)
+
+        self.g3 = self.g3.transpose()
+        d3 = d3.transpose()
+
+        assert (self.g3.shape == d3.shape)
+
+        assert (self.g3.astype(bool).max(axis=0) == d3.astype(bool).max(axis=0)).all()
+
+        unmatched_g3 = range(len(self.g3))
+        matched = dict()
+
+        for i in xrange(len(d3)):
+            new_unmatched_g3 = []
+            for j in unmatched_g3:
+                if not (d3[i] == self.g3[j]).all():
+                    new_unmatched_g3.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g3 = new_unmatched_g3
+
+        print(unmatched_g3)
+
+        assert (len(unmatched_g3) == 0)
+
+        assert (self.g3.astype(bool) == d3.astype(bool)).all()
+
     def test_call_multiprocessing_queue_spams_trainDL_1(self):
         d = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
             self.g.astype(float),
@@ -241,6 +346,101 @@ class TestSpamsSandbox(object):
         print(unmatched_g3)
 
         assert (len(unmatched_g3) == 0)
+
+    def test_call_multiprocessing_queue_spams_trainDL_3(self):
+        d = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
+            self.g.astype(float),
+            D=self.g.astype(float),
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d = (d != 0)
+
+        self.g = self.g.transpose()
+        d = d.transpose()
+
+        assert (self.g.shape == d.shape)
+
+        assert (self.g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(self.g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == self.g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (self.g.astype(bool) == d.astype(bool)).all()
+
+    @nose.plugins.attrib.attr("3D")
+    def test_call_multiprocessing_queue_spams_trainDL_4(self):
+        d3 = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
+            self.g3.astype(float),
+            D=self.g3.astype(float),
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d3 = (d3 != 0)
+
+        self.g3 = self.g3.transpose()
+        d3 = d3.transpose()
+
+        assert (self.g3.shape == d3.shape)
+
+        assert (self.g3.astype(bool).max(axis=0) == d3.astype(bool).max(axis=0)).all()
+
+        unmatched_g3 = range(len(self.g3))
+        matched = dict()
+
+        for i in xrange(len(d3)):
+            new_unmatched_g3 = []
+            for j in unmatched_g3:
+                if not (d3[i] == self.g3[j]).all():
+                    new_unmatched_g3.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g3 = new_unmatched_g3
+
+        print(unmatched_g3)
+
+        assert (len(unmatched_g3) == 0)
+
+        assert (self.g3.astype(bool) == d3.astype(bool)).all()
 
     def test_run_multiprocessing_array_spams_trainDL_1(self):
         float_type = numpy.float64
@@ -514,6 +714,194 @@ class TestSpamsSandbox(object):
 
         assert (len(unmatched_g3) == 0)
 
+    def test_run_multiprocessing_array_spams_trainDL_3(self):
+        float_type = numpy.float64
+
+        g_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=self.g.ndim,
+            shape=self.g.shape,
+            flags=self.g.flags
+        )
+        g_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            g_array_type._dtype_.type
+        ).type(0)[()]))
+        g_array = multiprocessing.Array(
+            g_array_ctype,
+            numpy.product(g_array_type._shape_),
+            lock=False
+        )
+
+        g_numpy_array = numpy.frombuffer(
+            g_array,
+            dtype=g_array_type._dtype_
+        ).reshape(g_array_type._shape_)
+        g_numpy_array[:] = self.g
+        g_numpy_array = None
+
+        result_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=2,
+            shape=(self.g.shape[0], self.g.shape[1])
+        )
+        result_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            result_array_type._dtype_.type
+        ).type(0)[()]))
+        result_array = multiprocessing.Array(
+            result_array_ctype,
+            numpy.product(result_array_type._shape_),
+            lock=False
+        )
+
+        nanshe.box.spams_sandbox.run_multiprocessing_array_spams_trainDL(
+            result_array_type,
+            result_array,
+            g_array_type,
+            g_array,
+            False,
+            g_array_type,
+            g_array,
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d = numpy.frombuffer(
+            result_array,
+            dtype=float_type
+        ).reshape(result_array_type._shape_).copy()
+        d = (d != 0)
+
+        self.g = self.g.transpose()
+        d = d.transpose()
+
+        assert (self.g.shape == d.shape)
+
+        assert (self.g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(self.g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == self.g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (self.g.astype(bool) == d.astype(bool)).all()
+
+    @nose.plugins.attrib.attr("3D")
+    def test_run_multiprocessing_array_spams_trainDL_4(self):
+        float_type = numpy.float64
+
+        g3_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=self.g3.ndim,
+            shape=self.g3.shape,
+            flags=self.g3.flags
+        )
+        g3_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            g3_array_type._dtype_.type
+        ).type(0)[()]))
+        g3_array = multiprocessing.Array(
+            g3_array_ctype,
+            numpy.product(g3_array_type._shape_),
+            lock=False
+        )
+
+        g3_numpy_array = numpy.frombuffer(
+            g3_array,
+            dtype=g3_array_type._dtype_
+        ).reshape(g3_array_type._shape_)
+        g3_numpy_array[:] = self.g3
+        g3_numpy_array = None
+
+        result_array_type = numpy.ctypeslib.ndpointer(
+            dtype=float_type,
+            ndim=2,
+            shape=(self.g3.shape[0], self.g3.shape[1])
+        )
+        result_array_ctype = type(numpy.ctypeslib.as_ctypes(numpy.dtype(
+            result_array_type._dtype_.type
+        ).type(0)[()]))
+        result_array = multiprocessing.Array(
+            result_array_ctype,
+            numpy.product(result_array_type._shape_),
+            lock=False
+        )
+
+        nanshe.box.spams_sandbox.run_multiprocessing_array_spams_trainDL(
+            result_array_type,
+            result_array,
+            g3_array_type,
+            g3_array,
+            g3_array_type,
+            g3_array,
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d3 = numpy.frombuffer(
+            result_array,
+            dtype=float_type
+        ).reshape(result_array_type._shape_).copy()
+        d3 = (d3 != 0)
+
+        self.g3 = self.g3.transpose()
+        d3 = d3.transpose()
+
+        assert (self.g3.shape == d3.shape)
+
+        assert (self.g3.astype(bool).max(axis=0) == d3.astype(bool).max(axis=0)).all()
+
+        unmatched_g3 = range(len(self.g3))
+        matched = dict()
+
+        for i in xrange(len(d3)):
+            new_unmatched_g3 = []
+            for j in unmatched_g3:
+                if not (d3[i] == self.g3[j]).all():
+                    new_unmatched_g3.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g3 = new_unmatched_g3
+
+        print(unmatched_g3)
+
+        assert (len(unmatched_g3) == 0)
+
+        assert (self.g3.astype(bool) == d3.astype(bool)).all()
+
     def test_call_spams_trainDL_1(self):
         d = nanshe.box.spams_sandbox.call_spams_trainDL(
             self.g.astype(float),
@@ -604,6 +992,101 @@ class TestSpamsSandbox(object):
         print(unmatched_g3)
 
         assert (len(unmatched_g3) == 0)
+
+    def test_call_spams_trainDL_3(self):
+        d = nanshe.box.spams_sandbox.call_spams_trainDL(
+            self.g.astype(float),
+            D=self.g.astype(float),
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d = (d != 0)
+
+        self.g = self.g.transpose()
+        d = d.transpose()
+
+        assert (self.g.shape == d.shape)
+
+        assert (self.g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(self.g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == self.g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (self.g.astype(bool) == d.astype(bool)).all()
+
+    @nose.plugins.attrib.attr("3D")
+    def test_call_spams_trainDL_4(self):
+        d3 = nanshe.box.spams_sandbox.call_spams_trainDL(
+            self.g3.astype(float),
+            self.g3.astype(float),
+            **{
+                "gamma2" : 0,
+                "gamma1" : 0,
+                "numThreads" : 1,
+                "iter" : 10,
+                "modeD" : 0,
+                "posAlpha" : True,
+                "clean" : True,
+                "posD" : True,
+                "batchsize" : 256,
+                "lambda1" : 0.2,
+                "lambda2" : 0,
+                "mode" : 2
+            }
+        )
+        d3 = (d3 != 0)
+
+        self.g3 = self.g3.transpose()
+        d3 = d3.transpose()
+
+        assert (self.g3.shape == d3.shape)
+
+        assert (self.g3.astype(bool).max(axis=0) == d3.astype(bool).max(axis=0)).all()
+
+        unmatched_g3 = range(len(self.g3))
+        matched = dict()
+
+        for i in xrange(len(d3)):
+            new_unmatched_g3 = []
+            for j in unmatched_g3:
+                if not (d3[i] == self.g3[j]).all():
+                    new_unmatched_g3.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g3 = new_unmatched_g3
+
+        print(unmatched_g3)
+
+        assert (len(unmatched_g3) == 0)
+
+        assert (self.g3.astype(bool) == d3.astype(bool)).all()
 
     def teardown(self):
         self.p = None

--- a/tests/test_nanshe/test_imp/test_segment.py
+++ b/tests/test_nanshe/test_imp/test_segment.py
@@ -882,19 +882,19 @@ class TestSegment(object):
             g.astype(float),
             **{
                 "spams.trainDL" : {
-                "gamma2" : 0,
-                "gamma1" : 0,
-                 "numThreads" : 1,
-                 "K" : len(g),
-                 "iter" : 10,
-                 "modeD" : 0,
-                 "posAlpha" : True,
-                 "clean" : True,
-                 "posD" : True,
-                 "batchsize" : 256,
-                 "lambda1" : 0.2,
-                 "lambda2" : 0,
-                 "mode" : 2
+                    "gamma2" : 0,
+                    "gamma1" : 0,
+                    "numThreads" : 1,
+                    "K" : len(g),
+                    "iter" : 10,
+                    "modeD" : 0,
+                    "posAlpha" : True,
+                    "clean" : True,
+                    "posD" : True,
+                    "batchsize" : 256,
+                    "lambda1" : 0.2,
+                    "lambda2" : 0,
+                    "mode" : 2
                 }
             }
         )

--- a/tests/test_nanshe/test_imp/test_segment.py
+++ b/tests/test_nanshe/test_imp/test_segment.py
@@ -1029,6 +1029,228 @@ class TestSegment(object):
 
         assert (len(unmatched_g) == 0)
 
+    def test_generate_dictionary_4(self):
+        p = numpy.array([[27, 51],
+                         [66, 85],
+                         [77, 45]])
+
+        space = numpy.array((100, 100))
+        radii = numpy.array((5, 6, 7))
+
+        g = nanshe.syn.data.generate_hypersphere_masks(space, p, radii)
+
+        d = nanshe.imp.segment.generate_dictionary(
+            g.astype(numpy.float32),
+            g.astype(numpy.float32),
+            **{
+                "spams.trainDL" : {
+                    "gamma2" : 0,
+                    "gamma1" : 0,
+                    "numThreads" : 1,
+                    "iter" : 10,
+                    "modeD" : 0,
+                    "posAlpha" : True,
+                    "clean" : True,
+                    "posD" : True,
+                    "batchsize" : 256,
+                    "lambda1" : 0.2,
+                    "lambda2" : 0,
+                    "mode" : 2
+                }
+            }
+        )
+        d = (d != 0)
+
+        assert (g.shape == d.shape)
+
+        assert (g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (g.astype(bool) == d.astype(bool)).all()
+
+    def test_generate_dictionary_5(self):
+        p = numpy.array([[27, 51],
+                         [66, 85],
+                         [77, 45]])
+
+        space = numpy.array((100, 100))
+        radii = numpy.array((5, 6, 7))
+
+        g = nanshe.syn.data.generate_hypersphere_masks(space, p, radii)
+
+        d = nanshe.imp.segment.generate_dictionary(
+            g.astype(float),
+            g.astype(float),
+            **{
+                "spams.trainDL" : {
+                    "gamma2" : 0,
+                    "gamma1" : 0,
+                    "numThreads" : 1,
+                    "iter" : 10,
+                    "modeD" : 0,
+                    "posAlpha" : True,
+                    "clean" : True,
+                    "posD" : True,
+                    "batchsize" : 256,
+                    "lambda1" : 0.2,
+                    "lambda2" : 0,
+                    "mode" : 2
+                }
+            }
+        )
+        d = (d != 0)
+
+        assert (g.shape == d.shape)
+
+        assert (g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (g.astype(bool) == d.astype(bool)).all()
+
+    @nose.plugins.attrib.attr("3D")
+    def test_generate_dictionary_6(self):
+        p = numpy.array([[27, 51, 87],
+                         [66, 85, 55],
+                         [77, 45, 26]])
+
+        space = numpy.array((100, 100, 100))
+        radii = numpy.array((5, 6, 7))
+
+        g = nanshe.syn.data.generate_hypersphere_masks(space, p, radii)
+
+        d = nanshe.imp.segment.generate_dictionary(
+            g.astype(numpy.float32),
+            g.astype(numpy.float32),
+            **{
+                "spams.trainDL" : {
+                    "gamma2" : 0,
+                    "gamma1" : 0,
+                    "numThreads" : 1,
+                    "iter" : 10,
+                    "modeD" : 0,
+                    "posAlpha" : True,
+                    "clean" : True,
+                    "posD" : True,
+                    "batchsize" : 256,
+                    "lambda1" : 0.2,
+                    "lambda2" : 0,
+                    "mode" : 2
+                }
+            }
+        )
+        d = (d != 0)
+
+        assert (g.shape == d.shape)
+
+        assert (g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (g.astype(bool) == d.astype(bool)).all()
+
+    @nose.plugins.attrib.attr("3D")
+    def test_generate_dictionary_7(self):
+        p = numpy.array([[27, 51, 87],
+                         [66, 85, 55],
+                         [77, 45, 26]])
+
+        space = numpy.array((100, 100, 100))
+        radii = numpy.array((5, 6, 7))
+
+        g = nanshe.syn.data.generate_hypersphere_masks(space, p, radii)
+
+        d = nanshe.imp.segment.generate_dictionary(
+            g.astype(float),
+            g.astype(float),
+            **{
+                "spams.trainDL" : {
+                    "gamma2" : 0,
+                    "gamma1" : 0,
+                    "numThreads" : 1,
+                    "iter" : 10,
+                    "modeD" : 0,
+                    "posAlpha" : True,
+                    "clean" : True,
+                    "posD" : True,
+                    "batchsize" : 256,
+                    "lambda1" : 0.2,
+                    "lambda2" : 0,
+                    "mode" : 2
+                }
+            }
+        )
+        d = (d != 0)
+
+        assert (g.shape == d.shape)
+
+        assert (g.astype(bool).max(axis=0) == d.astype(bool).max(axis=0)).all()
+
+        unmatched_g = range(len(g))
+        matched = dict()
+
+        for i in xrange(len(d)):
+            new_unmatched_g = []
+            for j in unmatched_g:
+                if not (d[i] == g[j]).all():
+                    new_unmatched_g.append(j)
+                else:
+                    matched[i] = j
+
+            unmatched_g = new_unmatched_g
+
+        print(unmatched_g)
+
+        assert (len(unmatched_g) == 0)
+
+        assert (g.astype(bool) == d.astype(bool)).all()
+
     def test_generate_local_maxima_vigra_1(self):
         p = numpy.array([[27, 51],
                          [66, 85],


### PR DESCRIPTION
This provides support for an initial dictionary argument for all dictionary related functions, which is in turn properly formatted for SPAMS. The argument is optional and does not change the default behavior or usage dictionary generation functions. Includes 2D, 3D, single and double precision tests to verify that it works correctly.