### PR TITLE
Optionally include registration shift in result file

### DIFF
--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -456,7 +456,7 @@ def register_mean_offsets(frames2reg,
         else:
             temporaries_file.copy(reg_frames.group, results_file)
         if include_shift:
-            temporaries_file.copy(space_shift, results_file)
+            temporaries_file.copy(space_shift.name, results_file)
         frames2reg_fft = None
         reg_frames = None
         space_shift = None

--- a/nanshe/registerer.py
+++ b/nanshe/registerer.py
@@ -121,6 +121,13 @@ def main(*argv):
                         name=each_output_filename_components.internalDatasetName
                     )
 
+                    if parsed_args.parameters.get("include_shift", False):
+                        result_file.copy(
+                            "space_shift",
+                            output_file[each_output_filename_components.internalDirectory],
+                            name=each_output_filename_components.internalDatasetName + "_shift"
+                        )
+
                 # Copy all attributes from raw data to the final result.
                 output = output_file[
                     each_output_filename_components.internalDatasetName

--- a/tests/test_nanshe/test_registerer.py
+++ b/tests/test_nanshe/test_registerer.py
@@ -77,6 +77,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 
@@ -120,6 +121,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 
@@ -163,6 +165,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 
@@ -206,6 +209,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 
@@ -245,6 +249,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 
@@ -290,6 +295,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 
@@ -335,6 +341,7 @@ class TestRegisterer(object):
 
         b2 = None
         with h5py.File(self.result_filename, "a") as result_file:
+            assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
 

--- a/tests/test_nanshe/test_registerer.py
+++ b/tests/test_nanshe/test_registerer.py
@@ -76,7 +76,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
@@ -120,7 +120,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
@@ -164,7 +164,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
@@ -208,7 +208,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
@@ -248,7 +248,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
@@ -294,7 +294,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]
@@ -340,7 +340,7 @@ class TestRegisterer(object):
         )
 
         b2 = None
-        with h5py.File(self.result_filename, "a") as result_file:
+        with h5py.File(self.result_filename, "r") as result_file:
             assert "images" in result_file
             assert "attr" in result_file["images"].attrs
             assert "test" == result_file["images"].attrs["attr"]

--- a/tests/test_nanshe/test_registerer.py
+++ b/tests/test_nanshe/test_registerer.py
@@ -220,6 +220,44 @@ class TestRegisterer(object):
         assert (b2 == b).all()
 
 
+    def test_main_4a(self):
+        a = numpy.zeros((20,10,11), dtype=int)
+
+        a[:, 3:-3, 3:-3] = 1
+
+        b = numpy.ma.masked_array(a.copy())
+        b = nanshe.util.xnumpy.truncate_masked_frames(b)
+
+
+        with open(self.config_filename, "a") as config_file:
+            json.dump({"include_shift": True}, config_file)
+
+        with h5py.File(self.data_filename, "a") as data_file:
+            data_file["images"] = a
+            data_file["images"].attrs["attr"] = "test"
+
+        self.data_filepath = self.data_filename + "/" + "images"
+        self.result_filepath = self.result_filename + "/" + "images"
+
+        nanshe.registerer.main(
+            nanshe.registerer.__file__,
+            self.config_filename,
+            self.data_filepath,
+            self.result_filepath
+        )
+
+        b2 = None
+        with h5py.File(self.result_filename, "r") as result_file:
+            assert "images" in result_file
+            assert "images_shift" in result_file
+            assert "attr" in result_file["images"].attrs
+            assert "test" == result_file["images"].attrs["attr"]
+
+            b2 = result_file["images"][...]
+
+        assert (b2 == b).all()
+
+
     @nose.plugins.attrib.attr("3D")
     def test_main_0b(self):
         a = numpy.zeros((20,10,11,12), dtype=int)


### PR DESCRIPTION
Ensure the registration shift will be serialized to the result file when requested.