### PR TITLE
Switch `conda-server` to `anaconda-client`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,8 @@ after_success:
    - conda install conda-server
    - cd $HOME/miniconda/conda-bld/
    - conda convert -p osx-64 linux-64/nanshe*
-   - conda-server -t ${BS_TOKEN} upload linux-64/nanshe*
-   - conda-server -t ${BS_TOKEN} upload osx-64/nanshe*
+   - conda server -t ${BS_TOKEN} upload linux-64/nanshe*
+   - conda server -t ${BS_TOKEN} upload osx-64/nanshe*
 notifications:
   email: False
   webhooks: https://api.kato.im/rooms/a17f510ab0bcfd79de90a2f2887718bb86afdb4fcff8b4b87965b2bdf0c40ed/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ after_success:
    - if [ -z $TRAVIS_TAG ]; then exit 0 ; fi
    - git checkout $TRAVIS_TAG
    - source activate root
-   - conda install conda-server
+   - conda install anaconda-client
    - cd $HOME/miniconda/conda-bld/
    - conda convert -p osx-64 linux-64/nanshe*
    - conda server -t ${BS_TOKEN} upload linux-64/nanshe*


### PR DESCRIPTION
`conda-server` has been renamed to `anaconda-client`. So, we have to change the name used to download it. Also, switched to using the `conda-server` binary as a subcommand.