### PR TITLE
Trigger docker image build on Docker Hub after uploading binaries to Anaconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ after_success:
    - conda convert -p osx-64 linux-64/nanshe*
    - conda server -t ${AS_TOKEN} upload linux-64/nanshe*
    - conda server -t ${AS_TOKEN} upload osx-64/nanshe*
-   - curl -H "Content-Type: application/json" --data '&#123;"docker_tag_name": "latest"&#125;' -X POST "https://registry.hub.docker.com/u/jakirkham/nanshe/trigger/${DH_TOKEN}/"
+   - "curl -H \"Content-Type: application/json\" --data '&#123;\"docker_tag_name\": \"latest\"&#125;' -X POST \"https://registry.hub.docker.com/u/jakirkham/nanshe/trigger/${DH_TOKEN}/\""
 notifications:
   email: False
   webhooks: https://api.kato.im/rooms/a17f510ab0bcfd79de90a2f2887718bb86afdb4fcff8b4b87965b2bdf0c40ed/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ after_success:
    - conda convert -p osx-64 linux-64/nanshe*
    - conda server -t ${AS_TOKEN} upload linux-64/nanshe*
    - conda server -t ${AS_TOKEN} upload osx-64/nanshe*
+   - curl -H "Content-Type: application/json" --data '&#123;"docker_tag_name": "latest"&#125;' -X POST "https://registry.hub.docker.com/u/jakirkham/nanshe/trigger/${DH_TOKEN}/"
 notifications:
   email: False
   webhooks: https://api.kato.im/rooms/a17f510ab0bcfd79de90a2f2887718bb86afdb4fcff8b4b87965b2bdf0c40ed/travis


### PR DESCRIPTION
Fixes #279.

Simple `POST` command that triggers a Docker Hub build after uploading new binaries during a release.