### PR TITLE
Pin some packages for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
    - conda install drmaa
    # Install sphinx 1.3 and friends to build documentation.
+   - echo "sphinx 1.3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install sphinx
    - conda install cloud_sptheme
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
    - conda install drmaa
    # Install sphinx 1.3 and friends to build documentation.
-   - conda install "sphinx>=1.3,<2"
+   - conda install sphinx
    - conda install cloud_sptheme
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    # Also, install docstring-coverage to get information about documentation coverage.

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    # Also, install docstring-coverage to get information about documentation coverage.
    - conda install nose-timer
+   - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
    - conda install docstring-coverage
    - conda install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ install:
    - echo $VERSION
    - python setup.py bdist_conda
    # Setup environment for nanshe and install it with all dependencies.
-   - conda create --use-local -n nanshenv python=$TRAVIS_PYTHON_VERSION nanshe==$VERSION
-   - source activate nanshenv
+   - conda create --use-local -n testenv python=$TRAVIS_PYTHON_VERSION nanshe==$VERSION
+   - source activate testenv
    # Install DRMAA with Python support.
    - .travis_scripts/install_sge.sh
    - export SGE_ROOT=/var/lib/gridengine

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -31,7 +31,7 @@ build:
         - script:
             name: Install dependencies for building docs.
             code: |-
-                conda install -y "sphinx>=1.3,<2"
+                conda install -y sphinx
                 conda install -y cloud_sptheme
 
         - script:

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -39,6 +39,7 @@ build:
             name: Install dependencies for profiling and monitoring coverage.
             code: |-
                 conda install -y nose-timer
+                echo "coverage 3.*" >> /opt/conda/envs/testenv/conda-meta/pinned
                 conda install -y coverage
                 conda install -y docstring-coverage
                 conda install -y python-coveralls

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -31,6 +31,7 @@ build:
         - script:
             name: Install dependencies for building docs.
             code: |-
+                echo "sphinx 1.3.*" >> /opt/conda/envs/testenv/conda-meta/pinned
                 conda install -y sphinx
                 conda install -y cloud_sptheme
 

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -20,8 +20,8 @@ build:
         - script:
             name: Create Conda Environment with package and dependencies.
             code: |-
-                conda create -y --use-local -n nanshenv nanshe==$(python setup.py --version)
-                source activate nanshenv
+                conda create -y --use-local -n testenv nanshe==$(python setup.py --version)
+                source activate testenv
 
         - script:
             name: Install dependencies for cluster support.


### PR DESCRIPTION
* Pins `sphinx` to `1.3.*`. (was downgrading to `1.2.*` for no reason)
* Pins `coverage` to `3.*`. (was upgrading to `4.*`)
* Renames the test environment on Travis CI to `testenv` from `nanshenv`.