### PR TITLE
Redirect binary publications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ after_success:
    - conda convert -p osx-64 linux-64/nanshe*
    - conda server -t ${AS_TOKEN} upload linux-64/nanshe*
    - conda server -t ${AS_TOKEN} upload osx-64/nanshe*
-   - "curl -H \"Content-Type: application/json\" --data '&#123;\"docker_tag_name\": \"latest\"&#125;' -X POST \"https://registry.hub.docker.com/u/jakirkham/nanshe/trigger/${DH_TOKEN}/\""
+   - "curl -H \"Content-Type: application/json\" --data '&#123;\"docker_tag_name\": \"latest\"&#125;' -X POST \"https://registry.hub.docker.com/u/nanshe/nanshe/trigger/${DH_TOKEN}/\""
 notifications:
   email:
     - $TO_EMAIL

--- a/README.rst
+++ b/README.rst
@@ -165,8 +165,8 @@ If only one is specified, then only an upper or lower bound exists.
    :target: https://www.gnu.org/copyleft/gpl.html
 .. |Documentation| image:: https://img.shields.io/badge/docs-current-9F21E9.svg
    :target: http://jakirkham.github.io/nanshe/
-.. |Anaconda Release| image:: https://anaconda.org/jakirkham/nanshe/badges/version.svg
-   :target: https://anaconda.org/jakirkham/nanshe
+.. |Anaconda Release| image:: https://anaconda.org/nanshe/nanshe/badges/version.svg
+   :target: https://anaconda.org/nanshe/nanshe
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
    :alt: Join the chat at https://gitter.im/jakirkham/nanshe
    :target: https://gitter.im/jakirkham/nanshe?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/nanshe/__init__.py
+++ b/nanshe/__init__.py
@@ -62,7 +62,7 @@ preferable.
 Conda
 ===============================================================================
 Current packages can be found on our anaconda_ channel
-( https://anaconda.org/jakirkham/nanshe ). New ones are released every time a
+( https://anaconda.org/nanshe/nanshe ). New ones are released every time a
 passing tagged release is pushed to the ``master`` branch on GitHub. It is also
 possible to build packages for conda_ for non-release commits as we do in our
 continuous integration strategy.


### PR DESCRIPTION
* Publish `nanshe` packages to the `nanshe` channel on <https://anaconda.org/>.
* Trigger build of the `nanshe` docker image on Docker Hub under the `nanshe` organization.
* Note the new location for finding binaries in the documentation.
* Update our release package badge to point to the new location.